### PR TITLE
package: update "semver" to v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "extend": "~3.0.0",
-    "semver": "~4.3.6"
+    "semver": "~5.0.1"
   }
 }


### PR DESCRIPTION
I can't use `agent-base` in `webpack`, because of a `semver` bug which has been fixed in the latest version.

https://github.com/npm/node-semver/commit/41b56fa573d1ef0d1718777a8a21ae1b57ebcd83