### PR TITLE
fix dangling sockets problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ node_js:
   - "3"
   - "4"
   - "5"
+  - "6"
+  - "7"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/agent.js
+++ b/agent.js
@@ -100,7 +100,9 @@ Agent.prototype.addRequest = function addRequest (req, host, port, localAddress)
       }
     } else {
       req.onSocket(socket);
-      socket.unref();
+      if (typeof socket.unref === 'function') {
+        socket.unref();
+      }
     }
   });
   sync = false;

--- a/agent.js
+++ b/agent.js
@@ -100,6 +100,7 @@ Agent.prototype.addRequest = function addRequest (req, host, port, localAddress)
       }
     } else {
       req.onSocket(socket);
+      socket.unref();
     }
   });
   sync = false;

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ var WebSocket = require('ws');
 var assert = require('assert');
 var events = require('events');
 var inherits = require('util').inherits;
+var semver = require('semver');
 var Agent = require('../');
 
 describe('Agent', function () {
@@ -246,6 +247,10 @@ describe('"http" module', function () {
   });
 
   it('has no any dangling sockets', function (done) {
+      // unref is not supported for node < 0.9.1
+      if (semver.lt(process.version, '0.9.1')) {
+          return done()
+      }
       var agent = new Agent(function (req, opts, fn) {
           fn(null, net.connect(opts));
       });

--- a/test/test.js
+++ b/test/test.js
@@ -244,6 +244,25 @@ describe('"http" module', function () {
       agent: agent
     });
   });
+
+  it('has no any dangling sockets', function (done) {
+      var agent = new Agent(function (req, opts, fn) {
+          fn(null, net.connect(opts));
+      });
+      function getActiveSockets() {
+          return process._getActiveHandles().filter(function (handler) {
+              return handler.constructor.name === 'Socket'
+          });
+      }
+      // Some sockets are created outside of this test
+      const initialSockets = getActiveSockets()
+      http.get({
+          host: 'google.com',
+          agent: agent
+      });
+      assert.equal(initialSockets.length, getActiveSockets().length);
+      done();
+  })
 });
 
 describe('"https" module', function () {


### PR DESCRIPTION
This resolves problems with dangling sockets (zkat/make-fetch-happen#29) by calling [socket.unref()](https://nodejs.org/api/net.html#net_socket_unref)