### PR TITLE
Hot Fix

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.1.1 / 2017-05-30
+==================
+
+  * disabled unref by default (#7) it can be enabled using `UNREF_SOCKETS` environment variable.
 
 2.1.0 / 2017-05-26
 ==================

--- a/agent.js
+++ b/agent.js
@@ -100,7 +100,7 @@ Agent.prototype.addRequest = function addRequest (req, host, port, localAddress)
       }
     } else {
       req.onSocket(socket);
-      if (typeof socket.unref === 'function') {
+      if (typeof socket.unref === 'function' && process.env.UNREF_SOCKETS) {
         socket.unref();
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-base",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Turn a function into an `http.Agent` instance",
   "main": "agent.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,9 @@ var inherits = require('util').inherits;
 var semver = require('semver');
 var Agent = require('../');
 
+// Enable UNREF_SOCKETS environment variable (disabled by default #7)
+process.env.UNREF_SOCKETS = true
+
 describe('Agent', function () {
   describe('subclass', function () {
     it('should be subclassable', function (done) {


### PR DESCRIPTION
This PR reverts breaking change causing by  using unref & until a better workaround provided for dangling socket problem, this will keep users safe from a breaking change (#7) 2.1.0 behavior can be enabled by using `UNREF_SOCKETS` environment variable.  I've just prepared history and version bumps to help this fix done sooner.
Also if you prefer we can just revert back every fix without using environment variables.