### PR TITLE
Ensure that `https.get()` uses the patched `https.request()` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/patch-core.js
+++ b/patch-core.js
@@ -24,3 +24,15 @@ https.request = (function(request) {
     return request.call(https, options, cb);
   };
 })(https.request);
+
+/**
+ * This is needed for Node.js >= 9.0.0 to make sure `https.get()` uses the
+ * patched `https.request()`.
+ *
+ * Ref: https://github.com/nodejs/node/commit/5118f31
+ */
+https.get = function(options, cb) {
+  const req = https.request(options, cb);
+  req.end();
+  return req;
+};


### PR DESCRIPTION
Since nodejs/node@5118f31, `https.get()` no longer uses `exports.request`.