### PR TITLE
close free sockets

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ Agent.prototype.addRequest = function addRequest(req, _opts) {
   let timeout;
   let timedOut = false;
   const timeoutMs = this.timeout;
+  const freeSocket = this.freeSocket;
 
   function onerror(err) {
     if (req._hadError) return;
@@ -133,6 +134,10 @@ Agent.prototype.addRequest = function addRequest(req, _opts) {
       // responsibility for this `req` to the Agent from here on
       socket.addRequest(req, opts);
     } else if (socket) {
+      function onfree() {
+        freeSocket(socket, opts);
+      }
+      socket.on('free', onfree);
       req.onSocket(socket);
     } else {
       const err = new Error(
@@ -157,4 +162,9 @@ Agent.prototype.addRequest = function addRequest(req, _opts) {
   } catch (err) {
     Promise.reject(err).catch(callbackError);
   }
+};
+
+Agent.prototype.freeSocket = function freeSocket(socket, opts) {
+  // TODO reuse sockets
+  socket.destroy();
 };

--- a/test/test.js
+++ b/test/test.js
@@ -398,6 +398,30 @@ describe('"http" module', function() {
     });
   });
 
+  it('should free sockets after use', function(done) {
+    var agent = new Agent(function(req, opts, fn) {
+      var socket = net.connect(opts);
+      fn(null, socket);
+    });
+
+    // add HTTP server "request" listener
+    var gotReq = false;
+    server.once('request', function(req, res) {
+      gotReq = true;
+      res.end();
+    });
+
+    var info = url.parse('http://127.0.0.1:' + port + '/foo');
+    info.agent = agent;
+    http.get(info, function(res) {
+      res.socket.emit('free');
+      assert.equal(true, res.socket.destroyed);
+      assert(gotReq);
+      done();
+    });
+  });
+
+
   describe('PassthroughAgent', function() {
     it('should pass through to `http.globalAgent`', function(done) {
       // add HTTP server "request" listener


### PR DESCRIPTION
The issue is discussed thoroughly here
https://github.com/zkat/pacote/issues/138

The various fetching libraries signal free proxy sockets with ``free`` event. Close the socket instead of leaving them uncontrollably open and eventually exploding due to high number of open connections. This is a major blocker in some cases because some corporate proxies have hard limits on concurrently open connections.