### PR TITLE
skip https.request patching if already done

### DIFF
--- a/patch-core.js
+++ b/patch-core.js
@@ -8,21 +8,25 @@ const https = require('https');
  *
  * There is currently no PR attempting to move this property upstream.
  */
-https.request = (function(request) {
-  return function(_options, cb) {
-    let options;
-    if (typeof _options === 'string') {
-      options = url.parse(_options);
-    } else {
-      options = Object.assign({}, _options);
-    }
-    if (null == options.port) {
-      options.port = 443;
-    }
-    options.secureEndpoint = true;
-    return request.call(https, options, cb);
-  };
-})(https.request);
+const patchMarker = "__agent_base_https_request_patched__";
+if (!https.request[patchMarker]) {
+  https.request = (function(request) {
+    return function(_options, cb) {
+      let options;
+      if (typeof _options === 'string') {
+        options = url.parse(_options);
+      } else {
+        options = Object.assign({}, _options);
+      }
+      if (null == options.port) {
+        options.port = 443;
+      }
+      options.secureEndpoint = true;
+      return request.call(https, options, cb);
+    };
+  })(https.request);
+  https.request[patchMarker] = true;
+}
 
 /**
  * This is needed for Node.js >= 9.0.0 to make sure `https.get()` uses the

--- a/test/test.js
+++ b/test/test.js
@@ -560,6 +560,17 @@ describe('"https" module', function() {
     });
   });
 
+  it('should not re-patch https.request', () => {
+    var patchModulePath = "../patch-core";
+    var patchedRequest = https.request;
+
+    delete require.cache[require.resolve(patchModulePath)];
+    require(patchModulePath);
+
+    assert.equal(patchedRequest, https.request);
+    assert.equal(true, https.request.__agent_base_https_request_patched__);
+  });
+
   describe('PassthroughAgent', function() {
     it('should pass through to `https.globalAgent`', function(done) {
       // add HTTP server "request" listener


### PR DESCRIPTION
Ran into the same issue as described in #22 when using PubNub JavaScript SDK, which includes this via `superagent-proxy`.

This fix prevents re-patching `https` method for each test executed by `jest` by checking for a marker to flag that the patch is already done.

fixes #22