### PR TITLE
Support 3-argument `.get()` methods

### DIFF
--- a/patch-core.js
+++ b/patch-core.js
@@ -30,7 +30,17 @@ https.request = (function(request) {
  *
  * Ref: https://github.com/nodejs/node/commit/5118f31
  */
-https.get = function(options, cb) {
+https.get = function (_url, _options, cb) {
+    let options;
+    if (typeof _url === 'string' && _options && typeof _options !== 'function') {
+      options = Object.assign({}, url.parse(_url), _options);
+    } else if (!_options && !cb) {
+      options = _url;
+    } else if (!cb) {
+      options = _url;
+      cb = _options;
+    }
+
   const req = https.request(options, cb);
   req.end();
   return req;

--- a/test/test.js
+++ b/test/test.js
@@ -542,6 +542,25 @@ describe('"https" module', function() {
     });
   });
 
+  it('should support the 3-argument `https.get()`', function(done) {
+    var agent = new Agent(function(req, opts, fn) {
+      assert.equal('google.com', opts.host);
+      assert.equal('/q', opts.pathname || opts.path);
+      assert.equal('881', opts.port);
+      assert.equal('bar', opts.foo);
+      done();
+    });
+
+    https.get(
+      'https://google.com:881/q',
+      {
+        host: 'google.com',
+        foo: 'bar',
+        agent: agent
+      }
+    );
+  });
+
   it('should default to port 443', function(done) {
     var agent = new Agent(function(req, opts, fn) {
       assert.equal(true, opts.secureEndpoint);


### PR DESCRIPTION
Fixes https://github.com/TooTallNate/node-agent-base/issues/24