### PR TITLE
Add `protocol` property to Agent class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ namespace createAgent {
 		public requests: http.ClientRequest[];
 		private promisifiedCallback?: createAgent.AgentCallbackPromise;
 		private explicitDefaultPort?: number;
+		private explicitProtocol?: string;
 
 		constructor(
 			callback?: createAgent.AgentCallback | createAgent.AgentOptions,
@@ -121,6 +122,18 @@ namespace createAgent {
 
 		set defaultPort(v: number) {
 			this.explicitDefaultPort = v;
+		}
+
+		get protocol(): string {
+			if (typeof this.explicitProtocol === 'string') {
+				return this.explicitProtocol;
+			} else {
+				return isSecureEndpoint() ? 'https:' : 'http:';
+			}
+		}
+
+		set protocol(v: string) {
+			this.explicitProtocol = v;
 		}
 
 		callback(

--- a/test/test.ts
+++ b/test/test.ts
@@ -6,10 +6,7 @@ import listen from 'async-listen';
 import { Agent, RequestOptions } from '../src';
 
 const req = (opts: http.RequestOptions): Promise<http.IncomingMessage> => {
-	return new Promise(resolve => {
-		const req = http.request(opts, resolve);
-		req.end();
-	});
+	return new Promise(resolve => http.request(opts, resolve).end());
 };
 
 function json(res: http.IncomingMessage): Promise<any> {
@@ -63,6 +60,7 @@ describe('"http" module', () => {
 		const agent = new Agent(
 			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
 				gotCallback = true;
+				assert.equal(opts.secureEndpoint, false);
 				return net.connect(opts);
 			}
 		);
@@ -95,6 +93,7 @@ describe('"http" module', () => {
 	it('should not send a port number for the default port', async () => {
 		const agent = new Agent(
 			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
+				assert.equal(opts.secureEndpoint, false);
 				return net.connect(opts);
 			}
 		);
@@ -118,6 +117,48 @@ describe('"http" module', () => {
 			assert.equal(body.host, '127.0.0.1');
 		} finally {
 			server.close();
+		}
+	});
+
+	it('should work when overriding `http.globalAgent`', async () => {
+		let gotReq = false;
+		let gotCallback = false;
+
+		const agent = new Agent(
+			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
+				gotCallback = true;
+				assert.equal(opts.secureEndpoint, false);
+				return net.connect(opts);
+			}
+		);
+
+		const server = http.createServer((req, res) => {
+			gotReq = true;
+			res.setHeader('X-Foo', 'bar');
+			res.setHeader('X-Url', req.url || '/');
+			res.end();
+		});
+		await listen(server);
+
+		const addr = server.address();
+		if (typeof addr === 'string') {
+			throw new Error('Server did not bind to a port');
+		}
+
+		// Override the default `http.globalAgent`
+		const originalAgent = http.globalAgent;
+		http.globalAgent = agent;
+
+		try {
+			const info = url.parse(`http://127.0.0.1:${addr.port}/foo`);
+			const res = await req(info);
+			assert.equal('bar', res.headers['x-foo']);
+			assert.equal('/foo', res.headers['x-url']);
+			assert(gotReq);
+			assert(gotCallback);
+		} finally {
+			server.close();
+			http.globalAgent = originalAgent;
 		}
 	});
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,6 +5,11 @@ import assert from 'assert';
 import listen from 'async-listen';
 import { Agent, RequestOptions } from '../src';
 
+// In Node 10+ you can just override `http.globalAgent`, but for older Node
+// versions we have to patch the internal `_http_agent` module instead.
+// @ts-ignore
+import httpAgent from '_http_agent';
+
 const req = (opts: http.RequestOptions): Promise<http.IncomingMessage> => {
 	return new Promise(resolve => http.request(opts, resolve).end());
 };
@@ -152,9 +157,9 @@ describe('"http" module', () => {
 		}
 		const { port } = addr;
 
-		// Override the default `http.globalAgent`
-		const originalAgent = http.globalAgent;
-		http.globalAgent = agent;
+		// Override the default `http.Agent.globalAgent`
+		const originalAgent = httpAgent.globalAgent;
+		httpAgent.globalAgent = agent;
 
 		try {
 			const info = url.parse(`http://127.0.0.1:${port}/foo`);

--- a/test/test.ts
+++ b/test/test.ts
@@ -61,6 +61,7 @@ describe('"http" module', () => {
 			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
 				gotCallback = true;
 				assert.equal(opts.secureEndpoint, false);
+				assert.equal(opts.protocol, 'http:');
 				return net.connect(opts);
 			}
 		);
@@ -77,9 +78,10 @@ describe('"http" module', () => {
 		if (typeof addr === 'string') {
 			throw new Error('Server did not bind to a port');
 		}
+		const { port } = addr;
 
 		try {
-			const info = url.parse(`http://127.0.0.1:${addr.port}/foo`);
+			const info = url.parse(`http://127.0.0.1:${port}/foo`);
 			const res = await req({ agent, ...info });
 			assert.equal('bar', res.headers['x-foo']);
 			assert.equal('/foo', res.headers['x-url']);
@@ -94,6 +96,8 @@ describe('"http" module', () => {
 		const agent = new Agent(
 			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
 				assert.equal(opts.secureEndpoint, false);
+				assert.equal(opts.protocol, 'http:');
+				assert.equal(agent.defaultPort, port);
 				return net.connect(opts);
 			}
 		);
@@ -107,11 +111,12 @@ describe('"http" module', () => {
 		if (typeof addr === 'string') {
 			throw new Error('Server did not bind to a port');
 		}
+		const { port } = addr;
 
-		agent.defaultPort = addr.port;
+		agent.defaultPort = port;
 
 		try {
-			const info = url.parse(`http://127.0.0.1:${addr.port}/foo`);
+			const info = url.parse(`http://127.0.0.1:${port}/foo`);
 			const res = await req({ agent, ...info });
 			const body = await json(res);
 			assert.equal(body.host, '127.0.0.1');
@@ -128,6 +133,7 @@ describe('"http" module', () => {
 			(req: http.ClientRequest, opts: RequestOptions): net.Socket => {
 				gotCallback = true;
 				assert.equal(opts.secureEndpoint, false);
+				assert.equal(opts.protocol, 'http:');
 				return net.connect(opts);
 			}
 		);
@@ -144,13 +150,14 @@ describe('"http" module', () => {
 		if (typeof addr === 'string') {
 			throw new Error('Server did not bind to a port');
 		}
+		const { port } = addr;
 
 		// Override the default `http.globalAgent`
 		const originalAgent = http.globalAgent;
 		http.globalAgent = agent;
 
 		try {
-			const info = url.parse(`http://127.0.0.1:${addr.port}/foo`);
+			const info = url.parse(`http://127.0.0.1:${port}/foo`);
 			const res = await req(info);
 			assert.equal('bar', res.headers['x-foo']);
 			assert.equal('/foo', res.headers['x-url']);


### PR DESCRIPTION
Related to TooTallNate/node-socks-proxy-agent#39.