### PR TITLE
fix: compatibility with node 14 typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/debug": "4",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.17",
+    "@types/node": "^14.0.20",
     "@types/semver": "^7.1.0",
     "@types/ws": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "1.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,9 @@ namespace createAgent {
 		public sockets: {
 			[key: string]: net.Socket[];
 		};
+		public freeSockets: {
+			[key: string]: net.Socket[];
+		};
 		public requests: {
 			[key: string]: http.IncomingMessage[];
 		};
@@ -127,6 +130,7 @@ namespace createAgent {
 			this.maxFreeSockets = 1;
 			this.maxSockets = 1;
 			this.sockets = {};
+			this.freeSockets = {};
 			this.requests = {};
 			this.options = {};
 		}


### PR DESCRIPTION
**Description of Change**
This PR fixes compatibility issues with node 14 typings mentioned in #43 .
It should also solved this issue:  https://github.com/TooTallNate/node-https-proxy-agent/issues/108

**Release Notes**
- Updated @types/node to 14.0.20
- Added the missing `freeSockets` property in a similar way to how the `sockets` property is handled (declared and initialized for compatibility but not used).
