### PR TITLE
fix ERR_INVALID_PROTOCOL in NodeJS 15 when connect https url through http proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function isAgent(v: any): v is createAgent.AgentLike {
 function isSecureEndpoint(): boolean {
 	const { stack } = new Error();
 	if (typeof stack !== 'string') return false;
-	return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1);
+	return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1  || l.indexOf('node:https:') !== -1);
 }
 
 function createAgent(opts?: createAgent.AgentOptions): createAgent.Agent;


### PR DESCRIPTION
When I connect https url (https://example.com) through http proxy (http://127.0.0.1:1080) or create secure websocket connection (wss://example.com) in NodeJS v15.0.1, the following error occurred:

```
ERR_INVALID_PROTOCOL TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
    at new NodeError (node:internal/errors:258:15)
    at new ClientRequest (node:_http_client:155:11)
    at request (node:https:313:10)
    at get (node:https:317:15)
    at initAsClient (D:\0\node_modules\ws\lib\websocket.js:538:31)
    at new WebSocket (D:\0\node_modules\ws\lib\websocket.js:72:7)
    ... {
  code: 'ERR_INVALID_PROTOCOL'
}
```

The above Error is thrown due to agent.protocol !== 'https:'

node:_http_client:154
```js
      if (this.agent && this.agent.protocol)
        expectedProtocol = this.agent.protocol;
      
      ...
      
      if (protocol !== expectedProtocol) {
        throw new ERR_INVALID_PROTOCOL(protocol, expectedProtocol);
  }

```

Then I inspected that agent.protocol was set in node-agent-base module and found out 
the following code has mis determined the caller module (http/https) of the agent.

```ts
get protocol(): string {
	if (typeof this.explicitProtocol === 'string') {
		return this.explicitProtocol;
	}
	return isSecureEndpoint() ? 'https:' : 'http:';
}


function isSecureEndpoint(): boolean {
	const { stack } = new Error();
	if (typeof stack !== 'string') return false;
	return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1);
}
```

NodeJS may have changed the error stack representation from `https.js:313:10` to `node:https:313:10`, which breaks the `isSecureEndpoint()` funciton.

Edit `isSecureEndpoint()` in `node_modules/agent-base/dist/src/index.js` by replacing the line 

```ts
return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1);
```

with

```ts
return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1 || l.indexOf('node:https:') !== -1);
```

temperorarily solved the ploblem.

similar problems:
https://github.com/npm/cli/issues/2003
