### PR TITLE
Fix `package.json#typings` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.2",
   "description": "Turn a function into an `http.Agent` instance",
   "main": "dist/src/index",
-  "typings": "dist/src/index",
+  "typings": "dist/src/index.d.ts",
   "files": [
     "dist/src",
     "src"


### PR DESCRIPTION
Fixes: https://stackoverflow.com/questions/63124462/how-to-fix-file-node-modules-dotenv-types-not-found-error-coming-from-j