### PR TITLE
Include types file extension in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.2",
   "description": "Turn a function into an `http.Agent` instance",
   "main": "dist/src/index",
-  "typings": "dist/src/index",
+  "typings": "dist/src/index.ts",
   "files": [
     "dist/src",
     "src"


### PR DESCRIPTION
Otherwise, the TypeScript language service used in VS Code (and other editors) won't pick up the types.